### PR TITLE
Use `window.setTimeout` to resolve `node/typings` issue

### DIFF
--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -59,7 +59,7 @@ export class TooltipDirective{
         }
 
         this.showDelay = this.delay || this.showDelay; 
-        this.showTimeoutId = setTimeout(() => {
+        this.showTimeoutId = window.setTimeout(() => {
             if (this.tooltip){
                 this.tooltip.className += " ng-tooltip-show";
             }
@@ -73,7 +73,7 @@ export class TooltipDirective{
 
         if (this.tooltip){
             this.tooltip.classList.remove("ng-tooltip-show");
-            this.hideTimeoutId = setTimeout(() => {
+            this.hideTimeoutId = window.setTimeout(() => {
                this.tooltip.parentNode.removeChild(this.tooltip);
                this.tooltip = null;
             }, this.hideDelay);


### PR DESCRIPTION
Resolves this error:

```
"Type 'Timer' is not assignable to type 'number'"
```

See this thread for context:
https://github.com/TypeStrong/atom-typescript/issues/1053