### PR TITLE
Hide when removed from dom

### DIFF
--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -35,6 +35,7 @@ export class TooltipDirective{
  
     @HostListener("focusout")
     @HostListener("mouseleave")
+    @HostListener ("mousedown")
     onMouseLeave() {
         this.hide();
     }

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -113,3 +113,4 @@ export class TooltipDirective{
         }
     }
 }
+


### PR DESCRIPTION
The tooltip persist if the parent element is removed from the DOM.
That can be a common case when the tooltip is attached to, for example, a button that route the user somewhere else.