### PR TITLE
Fixed a bug which caused the tooltip not to be shown on fast leave an…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,15 @@
-# Editor configuration, see http://editorconfig.org
+# http://editorconfig.org
+# .editorconfig from Angular 2+ (https://github.com/angular/angular/blob/master/.editorconfig)
 root = true
 
 [*]
 charset = utf-8
 indent_style = space
 indent_size = 2
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.md]
-max_line_length = off
+insert_final_newline = false
 trim_trailing_whitespace = false

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -5,7 +5,7 @@ import { Directive, ElementRef, HostListener, Input } from '@angular/core';
 })
 
 export class TooltipDirective{
-
+     
     constructor(private elementRef: ElementRef){}
 
     tooltip: any;
@@ -17,26 +17,23 @@ export class TooltipDirective{
     @Input('tooltip') tooltipText = "";
     @Input() placement = "top";
     @Input() delay = 0;
-    @Input('show-delay') showDelay = 0;
+    @Input('show-delay') showDelay = 0; 
     @Input('hide-delay') hideDelay = 300;
     @Input('z-index') zIndex = false;
 
     @HostListener("focusin")
     @HostListener("mouseenter")
-    // @HostListener("mousemove") -- not necessary in my opinion, maybe just a workaround to address the hideTimeout-bug
+    @HostListener("mousemove")
     onMouseEnter() {
         this.getElemPosition();
-        if (this.hideTimeoutId) {
-            // Clear the hide timeout => there may be an ongoing hide in progress, if you quickly leave and re-enter the tooltipped area
-            clearTimeout(this.hideTimeoutId);
-        }
+
         if (!this.tooltip){
             this.create();
             this.setPosition();
-            this.show();
+            this.show();     
         }
     }
-
+ 
     @HostListener("focusout")
     @HostListener("mouseleave")
     @HostListener ("mousedown")
@@ -49,12 +46,12 @@ export class TooltipDirective{
     }
 
     create(){
-        this.showDelay = this.delay || this.showDelay;
+        this.showDelay = this.delay || this.showDelay; 
         this.tooltip = document.createElement('span');
         this.tooltip.className += "ng-tooltip ng-tooltip-"+this.placement;
         this.tooltip.textContent = this.tooltipText;
         if (this.zIndex) this.tooltip.style.zIndex = this.zIndex;
-
+        
         document.body.appendChild(this.tooltip);
     }
 
@@ -63,7 +60,7 @@ export class TooltipDirective{
             clearTimeout(this.showTimeoutId);
         }
 
-        this.showDelay = this.delay || this.showDelay;
+        this.showDelay = this.delay || this.showDelay; 
         this.showTimeoutId = window.setTimeout(() => {
             if (this.tooltip){
                 this.tooltip.className += " ng-tooltip-show";
@@ -79,11 +76,8 @@ export class TooltipDirective{
         }
 
         if (this.tooltip){
+            this.tooltip.classList.remove("ng-tooltip-show");
             this.hideTimeoutId = window.setTimeout(() => {
-               // moved removal of the class inside the timeout
-               // => elsewhise the tooltip would be hidden immediately and just removed from the dom after the timeout,
-               // => doing this inside the timeout is also required to cancel the hide-timeout on re-enter
-               this.tooltip.classList.remove("ng-tooltip-show");
                this.tooltip.parentNode.removeChild(this.tooltip);
                this.tooltip = null;
             }, this.hideDelay);
@@ -110,11 +104,11 @@ export class TooltipDirective{
         }
 
         if (this.placement == 'left'){
-            this.tooltip.style.left = this.elemPosition.left - tooltipWidth - this.tooltipOffset +'px';
+            this.tooltip.style.left = this.elemPosition.left - tooltipWidth - this.tooltipOffset +'px'; 
         }
 
         if (this.placement == 'right'){
-            this.tooltip.style.left = this.elemPosition.left + elemWidth + this.tooltipOffset +'px';
+            this.tooltip.style.left = this.elemPosition.left + elemWidth + this.tooltipOffset +'px'; 
         }
 
         if (this.placement == 'left' || this.placement == 'right'){

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -5,7 +5,7 @@ import { Directive, ElementRef, HostListener, Input } from '@angular/core';
 })
 
 export class TooltipDirective{
-     
+
     constructor(private elementRef: ElementRef){}
 
     tooltip: any;
@@ -17,23 +17,26 @@ export class TooltipDirective{
     @Input('tooltip') tooltipText = "";
     @Input() placement = "top";
     @Input() delay = 0;
-    @Input('show-delay') showDelay = 0; 
+    @Input('show-delay') showDelay = 0;
     @Input('hide-delay') hideDelay = 300;
     @Input('z-index') zIndex = false;
 
     @HostListener("focusin")
     @HostListener("mouseenter")
-    @HostListener("mousemove")
+    // @HostListener("mousemove") -- not necessary in my opinion, maybe just a workaround to address the hideTimeout-bug
     onMouseEnter() {
         this.getElemPosition();
-
+        if (this.hideTimeoutId) {
+            // Clear the hide timeout => there may be an ongoing hide in progress, if you quickly leave and re-enter the tooltipped area
+            clearTimeout(this.hideTimeoutId);
+        }
         if (!this.tooltip){
             this.create();
             this.setPosition();
-            this.show();     
+            this.show();
         }
     }
- 
+
     @HostListener("focusout")
     @HostListener("mouseleave")
     @HostListener ("mousedown")
@@ -46,12 +49,12 @@ export class TooltipDirective{
     }
 
     create(){
-        this.showDelay = this.delay || this.showDelay; 
+        this.showDelay = this.delay || this.showDelay;
         this.tooltip = document.createElement('span');
         this.tooltip.className += "ng-tooltip ng-tooltip-"+this.placement;
         this.tooltip.textContent = this.tooltipText;
         if (this.zIndex) this.tooltip.style.zIndex = this.zIndex;
-        
+
         document.body.appendChild(this.tooltip);
     }
 
@@ -60,7 +63,7 @@ export class TooltipDirective{
             clearTimeout(this.showTimeoutId);
         }
 
-        this.showDelay = this.delay || this.showDelay; 
+        this.showDelay = this.delay || this.showDelay;
         this.showTimeoutId = window.setTimeout(() => {
             if (this.tooltip){
                 this.tooltip.className += " ng-tooltip-show";
@@ -76,8 +79,11 @@ export class TooltipDirective{
         }
 
         if (this.tooltip){
-            this.tooltip.classList.remove("ng-tooltip-show");
             this.hideTimeoutId = window.setTimeout(() => {
+               // moved removal of the class inside the timeout
+               // => elsewhise the tooltip would be hidden immediately and just removed from the dom after the timeout,
+               // => doing this inside the timeout is also required to cancel the hide-timeout on re-enter
+               this.tooltip.classList.remove("ng-tooltip-show");
                this.tooltip.parentNode.removeChild(this.tooltip);
                this.tooltip = null;
             }, this.hideDelay);
@@ -104,11 +110,11 @@ export class TooltipDirective{
         }
 
         if (this.placement == 'left'){
-            this.tooltip.style.left = this.elemPosition.left - tooltipWidth - this.tooltipOffset +'px'; 
+            this.tooltip.style.left = this.elemPosition.left - tooltipWidth - this.tooltipOffset +'px';
         }
 
         if (this.placement == 'right'){
-            this.tooltip.style.left = this.elemPosition.left + elemWidth + this.tooltipOffset +'px'; 
+            this.tooltip.style.left = this.elemPosition.left + elemWidth + this.tooltipOffset +'px';
         }
 
         if (this.placement == 'left' || this.placement == 'right'){

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -31,15 +31,24 @@ export class TooltipDirective {
 
   @HostListener('focusin')
   @HostListener('mouseenter')
-  @HostListener('mousemove')
+  // @HostListener('mousemove') -- not necessary in my opinion, maybe just a workaround to address the hideTimeout-bug
   onMouseEnter() {
+    if (this.hideTimeoutId) {
+      // Clear the hide timeout => there may be an ongoing hide in progress, if you quickly leave and re-enter the tooltipped area
+      clearTimeout(this.hideTimeoutId);
+    }
+
     this.getElemPosition();
 
-    if (!this.tooltip) {
+    if (this.tooltip) {
+      // ensurethe *-show class is present
+      this.tooltip.classList.add('ng-tooltip-show');
+    } else {
       this.create();
       this.setPosition();
       this.show();
     }
+
   }
 
   @HostListener('focusout')
@@ -87,6 +96,7 @@ export class TooltipDirective {
 
     if (this.tooltip) {
       this.tooltip.classList.remove('ng-tooltip-show');
+
       this.hideTimeoutId = window.setTimeout(() => {
         this.tooltip.parentNode.removeChild(this.tooltip);
         this.tooltip = null;

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -1,118 +1,128 @@
-import { Directive, ElementRef, HostListener, Input } from '@angular/core';
+import {Directive, ElementRef, HostListener, Input} from '@angular/core';
 
 @Directive({
-    selector: '[tooltip]'
+  selector: '[tooltip]'
 })
 
-export class TooltipDirective{
-     
-    constructor(private elementRef: ElementRef){}
+export class TooltipDirective {
 
-    tooltip: any;
-    elemPosition: any;
-    tooltipOffset: number = 8;
-    hideTimeoutId: number;
-    showTimeoutId: number;
 
-    @Input('tooltip') tooltipText = "";
-    @Input() placement = "top";
-    @Input() delay = 0;
-    @Input('show-delay') showDelay = 0; 
-    @Input('hide-delay') hideDelay = 300;
-    @Input('z-index') zIndex = false;
+  tooltip: any;
+  elemPosition: any;
+  tooltipOffset: number = 8;
+  hideTimeoutId: number;
+  showTimeoutId: number;
 
-    @HostListener("focusin")
-    @HostListener("mouseenter")
-    @HostListener("mousemove")
-    onMouseEnter() {
-        this.getElemPosition();
 
-        if (!this.tooltip){
-            this.create();
-            this.setPosition();
-            this.show();     
-        }
+  /* tslint:disable:no-input-rename */
+  /** renaming an input is considered as bad practise. see https://angular.io/guide/styleguide#avoid-aliasing-inputs-and-outputs
+   * But we'll leave it for now to preserve backward compatibility  */
+  @Input('tooltip') tooltipText = '';
+  @Input() placement = 'top';
+  @Input() delay = 0;
+  @Input('show-delay') showDelay = 0;
+  @Input('hide-delay') hideDelay = 300;
+  @Input('z-index') zIndex = false;
+
+  /* tslint:enable */
+
+  constructor(private elementRef: ElementRef) {
+  }
+
+  @HostListener('focusin')
+  @HostListener('mouseenter')
+  @HostListener('mousemove')
+  onMouseEnter() {
+    this.getElemPosition();
+
+    if (!this.tooltip) {
+      this.create();
+      this.setPosition();
+      this.show();
     }
- 
-    @HostListener("focusout")
-    @HostListener("mouseleave")
-    @HostListener ("mousedown")
-    onMouseLeave() {
-        this.hide();
-    }
+  }
 
-    getElemPosition(){
-        this.elemPosition = this.elementRef.nativeElement.getBoundingClientRect();
-    }
+  @HostListener('focusout')
+  @HostListener('mouseleave')
+  @HostListener('mousedown')
+  onMouseLeave() {
+    this.hide();
+  }
 
-    create(){
-        this.showDelay = this.delay || this.showDelay; 
-        this.tooltip = document.createElement('span');
-        this.tooltip.className += "ng-tooltip ng-tooltip-"+this.placement;
-        this.tooltip.textContent = this.tooltipText;
-        if (this.zIndex) this.tooltip.style.zIndex = this.zIndex;
-        
-        document.body.appendChild(this.tooltip);
-    }
+  getElemPosition() {
+    this.elemPosition = this.elementRef.nativeElement.getBoundingClientRect();
+  }
 
-    show(){
-        if (this.showTimeoutId) {
-            clearTimeout(this.showTimeoutId);
-        }
-
-        this.showDelay = this.delay || this.showDelay; 
-        this.showTimeoutId = window.setTimeout(() => {
-            if (this.tooltip){
-                this.tooltip.className += " ng-tooltip-show";
-            }
-        }, this.showDelay);
+  create() {
+    this.showDelay = this.delay || this.showDelay;
+    this.tooltip = document.createElement('span');
+    this.tooltip.className += 'ng-tooltip ng-tooltip-' + this.placement;
+    this.tooltip.textContent = this.tooltipText;
+    if (this.zIndex) {
+      this.tooltip.style.zIndex = this.zIndex;
     }
 
-    hide(){
-        clearTimeout(this.showTimeoutId);
+    document.body.appendChild(this.tooltip);
+  }
 
-        if (this.hideTimeoutId) {
-            clearTimeout(this.hideTimeoutId);
-        }
-
-        if (this.tooltip){
-            this.tooltip.classList.remove("ng-tooltip-show");
-            this.hideTimeoutId = window.setTimeout(() => {
-               this.tooltip.parentNode.removeChild(this.tooltip);
-               this.tooltip = null;
-            }, this.hideDelay);
-        }
+  show() {
+    if (this.showTimeoutId) {
+      clearTimeout(this.showTimeoutId);
     }
 
-    setPosition(){
-        let elemHeight = this.elementRef.nativeElement.offsetHeight;
-        let elemWidth = this.elementRef.nativeElement.offsetWidth;
-        let tooltipHeight = this.tooltip.clientHeight;
-        let tooltipWidth = this.tooltip.offsetWidth;
-        let scrollY = window.pageYOffset;
+    this.showDelay = this.delay || this.showDelay;
+    this.showTimeoutId = window.setTimeout(() => {
+      if (this.tooltip) {
+        this.tooltip.className += ' ng-tooltip-show';
+      }
+    }, this.showDelay);
+  }
 
-        if (this.placement == 'top'){
-            this.tooltip.style.top = (this.elemPosition.top + scrollY) - (tooltipHeight + this.tooltipOffset)+'px';
-        }
+  hide() {
+    clearTimeout(this.showTimeoutId);
 
-        if (this.placement == 'bottom'){
-            this.tooltip.style.top = (this.elemPosition.top + scrollY) + elemHeight + this.tooltipOffset +'px';
-        }
-
-        if (this.placement == 'top' || this.placement == 'bottom'){
-            this.tooltip.style.left = (this.elemPosition.left + elemWidth/2) - tooltipWidth/2 +'px';
-        }
-
-        if (this.placement == 'left'){
-            this.tooltip.style.left = this.elemPosition.left - tooltipWidth - this.tooltipOffset +'px'; 
-        }
-
-        if (this.placement == 'right'){
-            this.tooltip.style.left = this.elemPosition.left + elemWidth + this.tooltipOffset +'px'; 
-        }
-
-        if (this.placement == 'left' || this.placement == 'right'){
-            this.tooltip.style.top = (this.elemPosition.top + scrollY) + elemHeight/2 - this.tooltip.clientHeight/2+'px';
-        }
+    if (this.hideTimeoutId) {
+      clearTimeout(this.hideTimeoutId);
     }
+
+    if (this.tooltip) {
+      this.tooltip.classList.remove('ng-tooltip-show');
+      this.hideTimeoutId = window.setTimeout(() => {
+        this.tooltip.parentNode.removeChild(this.tooltip);
+        this.tooltip = null;
+      }, this.hideDelay);
+    }
+  }
+
+  setPosition() {
+    const elemHeight = this.elementRef.nativeElement.offsetHeight;
+    const elemWidth = this.elementRef.nativeElement.offsetWidth;
+    const tooltipHeight = this.tooltip.clientHeight;
+    const tooltipWidth = this.tooltip.offsetWidth;
+    const scrollY = window.pageYOffset;
+
+    if (this.placement === 'top') {
+      this.tooltip.style.top = (this.elemPosition.top + scrollY) - (tooltipHeight + this.tooltipOffset) + 'px';
+    }
+
+    if (this.placement === 'bottom') {
+      this.tooltip.style.top = (this.elemPosition.top + scrollY) + elemHeight + this.tooltipOffset + 'px';
+    }
+
+    if (this.placement === 'top' || this.placement === 'bottom') {
+      this.tooltip.style.left = (this.elemPosition.left + elemWidth / 2) - tooltipWidth / 2 + 'px';
+    }
+
+    if (this.placement === 'left') {
+      this.tooltip.style.left = this.elemPosition.left - tooltipWidth - this.tooltipOffset + 'px';
+    }
+
+    if (this.placement === 'right') {
+      this.tooltip.style.left = this.elemPosition.left + elemWidth + this.tooltipOffset + 'px';
+    }
+
+    if (this.placement === 'left' || this.placement === 'right') {
+      this.tooltip.style.top = (this.elemPosition.top + scrollY) + elemHeight / 2 - this.tooltip.clientHeight / 2 + 'px';
+    }
+  }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,10 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "import-blacklist": [true, "rxjs"],
+    "import-blacklist": [
+      true,
+      "rxjs"
+    ],
     "import-spacing": true,
     "indent": [
       true,
@@ -46,7 +49,7 @@
     "no-empty": false,
     "no-empty-interface": true,
     "no-eval": true,
-    "no-inferrable-types": true,
+    "no-inferrable-types": false,
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-string-throw": true,
@@ -70,6 +73,7 @@
     ],
     "radix": true,
     "semicolon": [
+      true,
       "always"
     ],
     "triple-equals": [
@@ -97,9 +101,18 @@
       "check-separator",
       "check-type"
     ],
-
-    "directive-selector": [true, "attribute", "app", "camelCase"],
-    "component-selector": [true, "element", "app", "kebab-case"],
+    "directive-selector": [
+      false,
+      "attribute",
+      "app",
+      "camelCase"
+    ],
+    "component-selector": [
+      true,
+      "element",
+      "app",
+      "kebab-case"
+    ],
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,


### PR DESCRIPTION
…d re-enter

Depending on the hideTimeout set on the tooltip the following behaviour
could be observed:
- Tooltip displayed correct on first enter on the "tooltipped" element
- After leaving the tooltipped element and re-entering it within the
  hideTimeout no tooltip was displayed

Fix:
- Cancel the hideTimeout if the mouse re-enters the tooltipped element
- Moved removal of the "*-show" - class inside the hideTimeout

Sorry for removing blanks on the line-endings and so causing more diff than necessary, IntelliJ did this automatically