### PR TITLE
Update tooltip.component.ts

### DIFF
--- a/src/app/tooltip/tooltip.component.ts
+++ b/src/app/tooltip/tooltip.component.ts
@@ -88,8 +88,8 @@ export class TooltipComponent {
     const isSvg = this.element instanceof SVGElement;
     const tooltip = this.elementRef.nativeElement;
 
-    const elementHeight = isSvg ? this.element.getBBox().height : this.element.offsetHeight;
-    const elementWidth = isSvg ? this.element.getBBox().width : this.element.offsetWidth;
+    const elementHeight = isSvg ? this.element.getBoundingClientRect().height : this.element.offsetHeight;
+    const elementWidth = isSvg ? this.element.getBoundingClientRect().width : this.element.offsetWidth;
     const tooltipHeight = tooltip.clientHeight;
     const tooltipWidth =  tooltip.clientWidth;
     const scrollY = window.pageYOffset;


### PR DESCRIPTION
`getBBox()` does not update its properties in case of applying "rotate" or another transformations on parent - it remains in local coords system. A `getBoundingClientRect()` method carries recalculated values.

Details in <https://stackoverflow.com/a/33699736>

It was tested by me on `Firefox 68.0.2` and `Chrome 76.0.3809.100`.