### PR TITLE
Fix auto-placement with more complex layouts

### DIFF
--- a/src/app/tooltip/tooltip.component.ts
+++ b/src/app/tooltip/tooltip.component.ts
@@ -156,7 +156,7 @@ export class TooltipComponent {
         const leftEdge = leftStyle;
         const rightEdge = leftStyle + tooltipWidth;
 
-        if ((topEdge < 0 || bottomEdge > document.body.clientHeight || leftEdge < 0 || rightEdge > document.body.clientWidth) && this.autoPlacement) {
+        if ((topEdge < 0 || bottomEdge > (window.innerHeight + scrollY) || leftEdge < 0 || rightEdge > document.body.clientWidth) && this.autoPlacement) {
             return false;
         }
 


### PR DESCRIPTION
The previous code used `document.body.clientHeight` to determine
if an element was out of the viewport. Unfortunately, this can cause
problems with layouts where the body element height is set to 100%.

Instead, we move back to using window.innerHeight, but add the current
scrollY, to determine if the bottom edge is off the screen. This way,
we can dynamically tell if the tooltip element would be scrolled out
of the user's view, and position it appropriately.