### PR TITLE
Add exportAs to the tooltip directive

### DIFF
--- a/src/app/tooltip/tooltip.directive.ts
+++ b/src/app/tooltip/tooltip.directive.ts
@@ -12,7 +12,8 @@ export interface AdComponent {
 }
 
 @Directive({
-    selector: '[tooltip]'
+    selector: '[tooltip]',
+    exportAs: 'tooltip',
 })
 
 export class TooltipDirective {


### PR DESCRIPTION
This change enables adding a template reference variable which can read the tooltip directive.

Before this change, if you added a tooltip to some custom component, the only way to get the instance of the tooltip directive was using `@ViewChild(TooltipDirective)`. Now it is also possible to create a template reference variable like `<some-component #tooltipRef="tooltip" [tooltip]="tooltipTemplate">`

More detailed explanation: https://netbasal.com/angular-2-take-advantage-of-the-exportas-property-81374ce24d26