### PR TITLE
fixes Rotation of content

### DIFF
--- a/src/app/tooltip/tooltip.component.html
+++ b/src/app/tooltip/tooltip.component.html
@@ -1,7 +1,6 @@
 <div *ngIf="isThemeLight" class="tooltip-arrow"></div>
 
-<div *ngIf="options['contentType'] === 'template' else htmlOrStringTemplate" 
-    [ngClass]="{'tooltip-arrow': isThemeLight }">
+<div *ngIf="options['contentType'] === 'template' else htmlOrStringTemplate">
 
 	<ng-container *ngTemplateOutlet="value"></ng-container>
 </div>


### PR DESCRIPTION
The tooltip-arrow class was used both, for the arrow and the content. Thus the content of a template was also rotated by 135 degree. This was introduced by a merge and seems to be a bug